### PR TITLE
Ignore System Volume Information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,7 +117,7 @@ $RECYCLE.BIN/
 *.lnk
 
 # Windows System Volume Information (Hidden folder at the root of every drive)
-System Volume Information/*
+System Volume Information/
 
 ### JetBrains ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,8 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# Windows System Volume Information (Hidden folder at the root of every drive)
+System Volume Information/*
 
 ### JetBrains ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm


### PR DESCRIPTION
System Volume Information is a hidden folder located at the root of every drive in Windows. 
This adds it to .gitignore

![image](https://cloud.githubusercontent.com/assets/14004943/20116506/60eaa3b6-a5f4-11e6-89a8-c84f32b25e68.png)
https://wiki.lunarsoft.net/wiki/System_Volume_Information