### PR TITLE
Fix background of "Add your reaction"

### DIFF
--- a/chrome-extension/themes/websites/github.scss
+++ b/chrome-extension/themes/websites/github.scss
@@ -438,7 +438,7 @@ button.muted-link {
     background: $theme-background-toolbar !important;
     svg {
         -webkit-filter: none !important;
-        background: $theme-background !important;
+        background: transparent !important;
         color: $theme-text !important;
     }
 }


### PR DESCRIPTION
Background of "Add your reaction" was previously darker than needed, on stock page there is no background so maybe it should match? The contrast between button svg colour and the header background is sufficient anyways