### PR TITLE
Small fix to background of discussion-item-header.

### DIFF
--- a/chrome-extension/themes/websites/github.scss
+++ b/chrome-extension/themes/websites/github.scss
@@ -472,6 +472,10 @@ button.muted-link {
     color: $theme-text !important;
 }
 
+.timeline-comment {
+    background: none !important;
+}
+
 //selecting them
 .drag-and-drop {
     .btn-link {


### PR DESCRIPTION
Very small fix to resolve the backgrounds:

Before
![chrome_2017-04-19_21-28-56](https://cloud.githubusercontent.com/assets/3183511/25200843/b6299990-2547-11e7-8384-0c5fb0881df8.png)

After
![chrome_2017-04-19_21-29-19](https://cloud.githubusercontent.com/assets/3183511/25200852/bfe9d382-2547-11e7-8dfc-703ba2752d6a.png)
