### PR TITLE
Adding more options for the Github theme, as Github Enterprise would be nice to have skinned as well.

### DIFF
--- a/chrome-extension/js/background/config.js
+++ b/chrome-extension/js/background/config.js
@@ -57,7 +57,7 @@ var CONFIG = {
 			name: 'Quora',
 			support: 'full',
 			hostRegExp: new RegExp('^www\.quora\.com$', 'i'),
-			creators: [ // 
+			creators: [ //
 				{ name: 'Abhishek Bhasker', link: 'http://Abhinickz.github.io' }
 			],
 			topContributors: [ // Top 3 contributors of fixes & improvements, excluding the creator
@@ -155,7 +155,7 @@ var CONFIG = {
 			key: 'github', // Must be the same as the object key
 			name: 'GitHub',
 			support: 'full',
-			hostRegExp: new RegExp('^(gist\.|)github\.com$', 'i'),
+			hostRegExp: new RegExp('^(git.*)|((gist\.|)github\.com)$', 'i'),
 			creators: [ // Who wrote the 80%+ of the skin?
 				{ name: 'Theis Villumsen', link: 'https://folkmann.it/' },
 				{ name: 'Nicolas Botello', link: 'http://nicolasbotello.com/' }
@@ -245,7 +245,7 @@ var CONFIG = {
 			topContributors: [ // Top 3 contributors of fixes & improvements, excluding the creator
 			]
 		},
-		
+
 		//--------------------------------------------------------------------
 		// Skins that still need additional work (support: 'in-development')
 		//--------------------------------------------------------------------
@@ -285,7 +285,7 @@ var CONFIG = {
 		'amazon': {
 			key: 'amazon', // Must be the same as the object key
 			name: 'Amazon',
-			support: 'in-development', // This skin still requires further improvement, help us by improving it! 
+			support: 'in-development', // This skin still requires further improvement, help us by improving it!
 			hostRegExp: new RegExp('\.amazon\.(co.uk|com|es|de|co.jp)$', 'i'),
 			creators: [ // Who wrote the 80%+ of the skin?
 				{ name: 'Guillermo Muela', link: 'https://github.com/Gmuela' }
@@ -296,7 +296,7 @@ var CONFIG = {
 		'mint': {
 			key: 'mint', // Must be the same as the object key
 			name: 'Mint',
-			support: 'in-development', // This skin still requires further improvement, help us by improving it! 
+			support: 'in-development', // This skin still requires further improvement, help us by improving it!
 			hostRegExp: new RegExp('mint.intuit.com', 'i'),
 			creators: [
 				{ name: 'EJ Seay', link: 'https://github.com/earlseay' }
@@ -307,7 +307,7 @@ var CONFIG = {
 		'craigslist': {
 			key: 'craigslist', // Must be the same as the object key
 			name: 'Craigslist ',
-			support: 'in-development', // This skin still requires further improvement, help us by improving it! 
+			support: 'in-development', // This skin still requires further improvement, help us by improving it!
 			hostRegExp: new RegExp('craigslist\.org$', 'i'),
 			creators: [ // Who wrote the 80%+ of the skin?
 				{ name: 'EJ Seay', link: 'https://github.com/earlseay' }
@@ -315,7 +315,7 @@ var CONFIG = {
 			topContributors: [ // Top 3 contributors of fixes & improvements, excluding the creator
 			]
 		},
-		
+
 		//--------------------------------------------------------------------
 		// Ask developers for help on the following websites
 		//--------------------------------------------------------------------


### PR DESCRIPTION
Hey there, just thought I'd make a PR to add more options to the Github theme. Since it's only checking to see if we're just on `github.com` I thought I'd include websites that also include `git` to include possible distributions of Github Enterprise.