### PR TITLE
Fix weird character in zh_TW

### DIFF
--- a/chrome-extension/_locales/zh_TW/messages.json
+++ b/chrome-extension/_locales/zh_TW/messages.json
@@ -6,6 +6,6 @@
 		"message": "Darkness - 精美的深色主題"
 	},
 	"appDescription": {
-		"message": "適用於Facebook, Google, YouTube, Gmail, Google Drive, Twitter, Messenger, Instagram, Reddit等網站的精美深色皮膚"
+		"message": "適用於Facebook, Google, YouTube, Gmail, Google Drive, Twitter, Messenger, Instagram, Reddit等網站的精美深色樣式"
 	}
 }


### PR DESCRIPTION
* in traditional chinese, we don't call it that way.

The word "skin" that we called "樣式"
"皮膚" reminds us of human skin. (but china people called "skin" with "皮膚" is normal)