### PR TITLE
Fix for Hacker News in Chrome

### DIFF
--- a/chrome-extension/js/background/config.js
+++ b/chrome-extension/js/background/config.js
@@ -345,7 +345,7 @@ var CONFIG = {
 			siteForDevelopers: true,
 			hostRegExp: new RegExp('^news\.ycombinator\.com$', 'i'),
 			creators: [ // Who wrote the 80%+ of the skin?
-				{ name: 'Łukasz Wójcik', link: 'https://lukaszwojcik.net' }
+				{ name: 'Łukasz Wójcik', link: 'https://www.lukaszwojcik.net/' }
 			],
 			topContributors: [ // Top 3 contributors of fixes & improvements, excluding the creator
 			]

--- a/chrome-extension/themes/websites/hackernews.scss
+++ b/chrome-extension/themes/websites/hackernews.scss
@@ -24,6 +24,14 @@ You should know: all the website's colors are inverted before skinning even star
 // General Elements Styling
 //----------------------------------------------------------------------------------------------------------------------------------------------------
 
+html {
+    background: none !important;
+}
+
+body {
+    min-height: auto !important;
+}
+
 // All buttons
 button {
     background-color: $theme-button-background !important;

--- a/chrome-extension/themes/websites/hackernews.scss
+++ b/chrome-extension/themes/websites/hackernews.scss
@@ -24,12 +24,23 @@ You should know: all the website's colors are inverted before skinning even star
 // General Elements Styling
 //----------------------------------------------------------------------------------------------------------------------------------------------------
 
+// Fix for Chrome: removing unstyled page margin and vertical scrollbars
+
 html {
     background: none !important;
 }
 
-body {
+html, body {
+    height: auto !important;
     min-height: auto !important;
+}
+
+// like above, but for Firefox
+
+@-moz-document url-prefix() {
+    html {
+        background: invert($theme-background) !important;
+    }
 }
 
 // All buttons


### PR DESCRIPTION
I recently noticed strange behavior on Hacker News in Chrome. With a Darkness theme turned on each HN page was getting additional unstyled margin causing the website look like this: https://i.imgur.com/6X3HWVY.png

The following PR fixes the problem so that HN experience remains consistent across both Chrome and Firefox.

(I'm also seizing this opportunity to slightly modify my homepage URL)